### PR TITLE
Fix/i18n sitemap and rss feed error

### DIFF
--- a/src/app/[locale]/feed.xml/route.ts
+++ b/src/app/[locale]/feed.xml/route.ts
@@ -2,29 +2,27 @@ import { NextResponse } from 'next/server';
 import { allPosts } from '@/.velite';
 import RSS from 'rss';
 
-import { defaultLocale } from '@/lib/navigation';
-import { getLocalizedUrl } from '@/utils/url';
 import { siteConfig } from '@/config/site';
 
 export function GET() {
 	const feedOptions = {
 		title: 'Tom Jin',
 		description: 'A developer website by Tom Jin.',
-		site_url: `${siteConfig.siteUrl}`,
-		feed_url: `${siteConfig.siteUrl}/feed.xml`,
-		language: 'zh-TW',
+		site_url: `${siteConfig.siteUrl}/en`,
+		feed_url: `${siteConfig.siteUrl}/en/feed.xml`,
+		language: 'en',
 		image_url: `${siteConfig.siteUrl}/opengraph-image.jpg`,
 	};
 
 	const feed = new RSS(feedOptions);
 
 	allPosts
-		.filter((post) => post.language === defaultLocale)
+		.filter((post) => post.language === 'en')
 		.map(post => {
 			feed.item({
 				title: post.title,
 				description: post.description,
-				url: `${siteConfig.siteUrl}/${post.permalink}`,
+				url: `${siteConfig.siteUrl}/en${post.permalink}`,
 				date: post.publishedAt,
 			});
 		});

--- a/src/app/[locale]/sitemap.ts
+++ b/src/app/[locale]/sitemap.ts
@@ -1,0 +1,13 @@
+import { siteConfig } from '@/config/site';
+
+export default async function sitemap() {
+	const routes = ['', 'about', 'blog', 'projects']
+		.map((route) => ({
+			url: `${siteConfig.siteUrl}/en/${route}`,
+			lastModified: new Date().toISOString().split('T')[0],
+		}));
+
+	return [
+		...routes,
+	];
+}

--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -3,7 +3,6 @@ import {
 	RiLinkedinBoxFill,
 	RiRssFill,
 } from 'react-icons/ri';
-import { default as NextLink } from 'next/link';
 
 import Link from '@/components/link';
 import { siteConfig } from '@/config/site';
@@ -30,7 +29,7 @@ function Footer() {
 					>
 						<RiLinkedinBoxFill className='size-6' />
 					</Link>
-					<NextLink
+					<Link
 						className='transition-colors duration-300 hover:text-base-300/60'
 						href='/feed.xml'
 						aria-label='RSS feed'
@@ -38,7 +37,7 @@ function Footer() {
 						rel='noopener noreferrer'
 					>
 						<RiRssFill className='size-6' />
-					</NextLink>
+					</Link>
 				</div>
 			</div>
 		</footer>


### PR DESCRIPTION
## Problem:
- 在訪問 `localhost:3000/en/feed.xml`、`sitemap.xml` 會跳錯
- 如果只加 `sitemap.ts` 跟 `feed.xml/route.ts` 在 [locale] folder，在訪問 `localhost:3000/feed.xml`會跳錯

## Solution
在 locale folder 跟 app folder 各別創建 `sitemap.ts`, `feed.xml/route.ts`，app folder 的負責生成中文語系 sitemap, feed, [locale] folder 負責生成英文語系 sitemap, feed。目前沒找到其他解法，代改善